### PR TITLE
Work with mm as unit for width and height

### DIFF
--- a/extensions/svg/deck.svg.js
+++ b/extensions/svg/deck.svg.js
@@ -194,7 +194,14 @@ This module provides a support for managed svg inclusion (allowing proper DOM ac
                 SVG.svg({
                     loadURL: attributes['src'],
                     onLoad: function($svg, w, h) {
-                        var px = function (str) {return str.replace("px", "")}
+                        var px = function (str) {return str.replace("px", "")
+				.replace("mm", "")
+				.replace("pt", "")
+				.replace("cm", "")
+				.replace("m", "")
+				.replace("in", "")
+				.replace("pc", "")
+				.replace("ft", "")}
                         var aa = $($svg.root());
                         aa.attr('width', '100%');
                         aa.attr('height', '100%');


### PR DESCRIPTION
The default configuration of inkscape seems to save image dimensions in mm rather than px. Despite being valid svg, these can not be used with the svg extension. With this fix, all image dimensions supported by inkscape are correctly interpreted.